### PR TITLE
Various build fixes for newer versions of gcc

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -7,7 +7,7 @@ CCMPI=
 #INCLUDES=-I$(critter_dir)/include
 INCLUDES=
 #DEFS=-DMKL -DCRITTER -DALGORITHMIC_SYMBOLS
-DEFS=-DMKL -DALGORITHMIC_SYMBOLS
+DEFS=
 #CFLAGS=-g -Wall -O3 -std=c++14 -mkl=parallel -xMIC-AVX512 ${DEFS} ${INCLUDES}
 CFLAGS=${DEFS} ${INCLUDES} -O3 -std=c++14 -fpermissive
 #LIB_PATH=-L$(critter_dir)/lib

--- a/config.mk
+++ b/config.mk
@@ -7,9 +7,9 @@ CCMPI=
 #INCLUDES=-I$(critter_dir)/include
 INCLUDES=
 #DEFS=-DMKL -DCRITTER -DALGORITHMIC_SYMBOLS
-DEFS=
+DEFS=-DMKL -DALGORITHMIC_SYMBOLS
 #CFLAGS=-g -Wall -O3 -std=c++14 -mkl=parallel -xMIC-AVX512 ${DEFS} ${INCLUDES}
-CFLAGS=${DEFS} ${INCLUDES}
+CFLAGS=${DEFS} ${INCLUDES} -O3 -std=c++14 -fpermissive
 #LIB_PATH=-L$(critter_dir)/lib
 LIB_PATH=
 #LIBS=-lcritter

--- a/src/alg/cholesky/cholinv/cholinv.h
+++ b/src/alg/cholesky/cholinv/cholinv.h
@@ -13,11 +13,11 @@ template<class SerializePolicy     = policy::cholinv::Serialize,
          class BaseCasePolicy      = policy::cholinv::NoReplication>
 class cholinv : public SerializePolicy, public IntermediatesPolicy, public BaseCasePolicy{
 public:
-  template<typename ScalarType, typename DimensionType>
+  template<typename ScalarT, typename DimensionT>
   class info{
   public:
-    using ScalarType = ScalarType;
-    using DimensionType = DimensionType;
+    using ScalarType = ScalarT;
+    using DimensionType = DimensionT;
     using alg_type = cholinv<SerializePolicy,IntermediatesPolicy,BaseCasePolicy>;
     using SP = SerializePolicy; using IP = IntermediatesPolicy; using BP = BaseCasePolicy;
     info(const info& p) : complete_inv(p.complete_inv), split(p.split), bc_mult_dim(p.bc_mult_dim), dir(p.dir) {}

--- a/src/alg/inverse/rectri/rectri.h
+++ b/src/alg/inverse/rectri/rectri.h
@@ -12,11 +12,11 @@ template<class SerializePolicy     = policy::rectri::Serialize,
          class IntermediatesPolicy = policy::rectri::SaveIntermediates>
 class rectri : public SerializePolicy, public IntermediatesPolicy{
 public:
-  template<typename ScalarType, typename DimensionType>
+  template<typename ScalarT, typename DimensionT>
   class info{
   public:
-    using ScalarType = ScalarType;
-    using DimensionType = DimensionType;
+    using ScalarType = ScalarT;
+    using DimensionType = DimensionT;
     using alg_type = rectri<SerializePolicy,IntermediatesPolicy>;
     using SP = SerializePolicy; using IP = IntermediatesPolicy;
     info(const info& p) : dir(p.dir) {}

--- a/src/alg/qr/cacqr/cacqr.h
+++ b/src/alg/qr/cacqr/cacqr.h
@@ -15,11 +15,11 @@ template<class SerializePolicy     = policy::cacqr::Serialize,
 class cacqr : public SerializePolicy, public IntermediatesPolicy{
 public:
   // cacqr is parameterized only by its cholesky-inverse factorization algorithm
-  template<typename ScalarType, typename DimensionType, typename CholeskyInversionType>
+  template<typename ScalarT, typename DimensionT, typename CholeskyInversionType>
   class info{
   public:
-    using ScalarType = ScalarType;
-    using DimensionType = DimensionType;
+    using ScalarType = ScalarT;
+    using DimensionType = DimensionT;
     using alg_type = cacqr<SerializePolicy,IntermediatesPolicy>;
     using cholesky_inverse_type = CholeskyInversionType;
     info(const info& p) : num_iter(p.num_iter),cholesky_inverse_args(p.cholesky_inverse_args),Q(p.Q),R(p.R) {}

--- a/src/alg/qr/cacqr/cacqr.hpp
+++ b/src/alg/qr/cacqr/cacqr.hpp
@@ -281,6 +281,6 @@ void cacqr<SerializePolicy,IntermediatesPolicy>::apply_Q(MatrixType& src, ArgTyp
 
 template<class SerializePolicy, class IntermediatesPolicy>
 template<typename MatrixType, typename ArgType, typename CommType>
-void cacqr<SerializePolicy,IntermediatesPolicy>::apply_QT(MatrixType& src, ArgType& args,CommType&& CommInfo) { static_assert(0,"not implemented"); }
+void cacqr<SerializePolicy,IntermediatesPolicy>::apply_QT(MatrixType& src, ArgType& args,CommType&& CommInfo) { assert(0) && "not implemented"; }
 
 }

--- a/src/alg/trsm/diaginvert/diaginvert.h
+++ b/src/alg/trsm/diaginvert/diaginvert.h
@@ -13,11 +13,11 @@ template<class SerializePolicy      = policy::tsqr::Serialize,
          class IntermediatesPolicy  = policy::tsqr::SaveIntermediates>
 class diaginvert : public SerializePolicy, public IntermediatesPolicy{
 public:
-  template<typename ScalarType, typename DimensionType>
+  template<typename ScalarT, typename DimensionT>
   class info{
   public:
-    using ScalarType = ScalarType;
-    using DimensionType = DimensionType;
+    using ScalarType = ScalarT;
+    using DimensionType = DimensionT;
     using alg_type = diaginvert<SerializePolicy,IntermediatesPolicy>;
     info(const info& p) : {}
     info(info&& p) : {}

--- a/src/matrix/matrix.h
+++ b/src/matrix/matrix.h
@@ -6,12 +6,12 @@
 // Local includes -- the policy classes
 #include "structure.h"
 
-template<typename ScalarType = double, typename DimensionType = int64_t, typename StructurePolicy = rect, typename OffloadPolicy = OffloadEachGemm>
+template<typename ScalarT = double, typename DimensionT = int64_t, typename StructurePolicy = rect, typename OffloadPolicy = OffloadEachGemm>
 class matrix : public StructurePolicy{
 public:
   // Type traits (some inherited from matrixBase)
-  using ScalarType = ScalarType;
-  using DimensionType = DimensionType;
+  using ScalarType = ScalarT;
+  using DimensionType = DimensionT;
   using StructureType = StructurePolicy;
   using OffloadType = OffloadPolicy;
 
@@ -50,7 +50,7 @@ public:
   inline DimensionType num_columns_global() const { return this->_globalDimensionX; }
 
   inline DimensionType offset_local(DimensionType coordX, DimensionType coordY, size_t buffer=0) const { return buffer != 2 ? _offset(coordX,coordY,this->_dimensionX,this->_dimensionY) : rect::_offset(coordX,coordY,this->_dimensionX,this->_dimensionY);}
-  inline DimensionType offset_global(DimensionType coordX, DimensionType coordY) const { static_assert(0,"not implemented"); return -1;}//TODO
+inline DimensionType offset_global(DimensionType coordX, DimensionType coordY) const { assert(0) && "not implemented"; return -1;}//TODO
 
   inline void swap() { ScalarType* ptr = this->data(); this->data() = this->scratch(); this->scratch() = ptr; } 
   inline void swap_pad() { ScalarType* ptr = this->scratch(); this->scratch() = this->pad(); this->pad() = ptr; } 

--- a/src/matrix/structure.hpp
+++ b/src/matrix/structure.hpp
@@ -171,6 +171,7 @@ void uppertri::_print(const ScalarType* data, DimensionType dimensionX, Dimensio
   }
 }
 
+/*
 template<typename ScalarType, typename DimensionType>
 void uppertri::_distribute_random(ScalarType* data, DimensionType dimensionX, DimensionType dimensionY, DimensionType globalDimensionX, DimensionType globalDimensionY, int64_t localPgridDimX, int64_t localPgridDimY,
                                   int64_t globalPgridDimX, int64_t globalPgridDimY, int64_t key){
@@ -204,7 +205,7 @@ void uppertri::_distribute_random(ScalarType* data, DimensionType dimensionX, Di
   }
   return;
 }
-
+*/
 
 template<typename ScalarType, typename DimensionType>
 void lowertri::_assemble(ScalarType*& data, ScalarType*& scratch, ScalarType*& pad, DimensionType& matrixNumElems, DimensionType dimensionX, DimensionType dimensionY){
@@ -224,12 +225,14 @@ void lowertri::_assemble_matrix(ScalarType*& data, ScalarType*& scratch, ScalarT
   std::memset(pad,0,matrixNumElems*sizeof(ScalarType));
 }
 
+/*
 template<typename ScalarType, typename DimensionType>
 void lowertri::_copy(ScalarType*& data, ScalarType*& scratch, ScalarType*& pad, ScalarType* const & source, DimensionType dimensionX, DimensionType dimensionY){
   DimensionType numElems = 0;
   _assemble(data, scratch, pad, numElems, dimensionX, dimensionY);
   std::memcpy(&data[0], &source[0], numElems*sizeof(T));
 }
+*/
 
 template<typename ScalarType, typename DimensionType>
 void lowertri::_print(const ScalarType* data, DimensionType dimensionX, DimensionType dimensionY){

--- a/src/util/util.hpp
+++ b/src/util/util.hpp
@@ -1,5 +1,5 @@
 /* Author: Edward Hutter */
-
+/*
 template<typename MatrixType, typename CommType>
 typename MatrixType::ScalarType util::get_identity_residual(MatrixType& Matrix, CommType&& CommInfo, MPI_Comm comm){
   // Should be offloaded to Matrix definition, which knows how best to iterate over matrix?
@@ -21,7 +21,7 @@ typename MatrixType::ScalarType util::get_identity_residual(MatrixType& Matrix, 
   MPI_Allreduce(MPI_IN_PLACE,&res,1,mpi_type<T>::type, MPI_SUM, comm);
   return res;
 }
-
+*/
 template<typename MatrixType, typename RefMatrixType, typename LambdaType>
 typename MatrixType::ScalarType
 util::residual_local(MatrixType& Matrix, RefMatrixType& RefMatrix, LambdaType&& Lambda, MPI_Comm slice, int64_t sliceX, int64_t sliceY, int64_t sliceDimX, int64_t sliceDimY){


### PR DESCRIPTION
Corrects several issues while building with gcc 8-10:
* Class template names cannot shadow static type fields
* Comment out unused template code
* Use `-fpermissive` flag to reduce certain errors to warnings.